### PR TITLE
Fix bug preventing using makeSubInfo to pass selection of fields to prisma

### DIFF
--- a/src/info.ts
+++ b/src/info.ts
@@ -180,7 +180,7 @@ export function makeSubInfo(
 
   const splittedPath = path.split('.')
   const fieldsToTraverse = splittedPath.slice()
-  let currentType = info.returnType
+  let currentType = returnType
   let currentSelectionSet = info.fieldNodes[0].selectionSet!
   let currentFieldName
   let parentType
@@ -204,7 +204,7 @@ export function makeSubInfo(
       )
     }
 
-    const currentFieldType = fields[currentFieldName].type
+    const currentFieldType = getDeepType(fields[currentFieldName].type)
     if (!(currentFieldType instanceof GraphQLObjectType)) {
       throw new Error(
         `Can't get subInfo for type ${currentFieldType} of field ${currentFieldName} on type ${currentType.toString()}`,


### PR DESCRIPTION
Enables use case referenced here:
- https://github.com/graphql-binding/graphql-binding/pull/69
- https://github.com/graphql-binding/graphql-binding/issues/80

Its now possible todo the following:

```
type Mutation {
  login(email: String!, password: String!): AuthPayload!
}

type AuthPayload {
  user: User!
  token: String!
}

type User {
  email: String!
  password: String!
  company: Company!
}

type Company {
  name: String!
}
```
```
async function login(parent, { email, password }, ctx, info) {
  // Passing the selection of info's field named `user`
  const user = await ctx.db.query.user({ where: { email } }, makeSubInfo(info, 'user'));

  if (user == null) {
    throw new Error(`User not found for email '${email}'`);
  }

  if (password !== user.password) {
    throw new Error('Invalid password');
  }

  return {
    user,
    token: getToken(user),
  };
}
```